### PR TITLE
Add Deep L translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "backstage/fields": "^0.6.0",
         "backstage/media": "dev-main",
         "backstage/redirects": "dev-main",
-        "backstage/translations": "^0.3",
+        "backstage/translations": "dev-feature/add-deep-l",
         "baspa/laravel-timezones": "^1.2",
         "codewithdennis/filament-select-tree": "^3.1",
         "filament/filament": "^3.3.10",


### PR DESCRIPTION
This pull request updates the dependency for `backstage/translations` in the `composer.json` file to use the `dev-feature/add-deep-l` branch instead of version `^0.3`. This change likely integrates new features or updates from the `add-deep-l` feature branch.